### PR TITLE
bug fix for typing

### DIFF
--- a/kipoiseq/extractors/vcf_matching.py
+++ b/kipoiseq/extractors/vcf_matching.py
@@ -3,11 +3,12 @@ import pandas as pd
 from kipoiseq.dataclasses import Variant, Interval
 from kipoiseq.extractors import MultiSampleVCF
 
-# pyranges is optional
 try:
-    import pyranges
+    from pyranges import PyRanges
 except ImportError:
-    pyranges = None
+    from typing import Any
+    PyRanges = Any
+
 
 __all__ = [
     'variants_to_pyranges',
@@ -16,7 +17,7 @@ __all__ = [
 ]
 
 
-def variants_to_pyranges(variants: List[Variant]) -> pyranges.PyRanges:
+def variants_to_pyranges(variants: List[Variant]) -> PyRanges:
     """
     Create pyrange object given list of variant objects.
 
@@ -36,7 +37,7 @@ def variants_to_pyranges(variants: List[Variant]) -> pyranges.PyRanges:
     return pyranges.PyRanges(df)
 
 
-def pyranges_to_intervals(pr: pyranges.PyRanges, interval_attrs: List[str] = None):
+def pyranges_to_intervals(pr: PyRanges, interval_attrs: List[str] = None):
     """
     Convert pyranges into list of intervals.
 
@@ -90,7 +91,7 @@ class BaseVariantMatcher:
             vcf_file: str,
             gtf_path: str = None,
             bed_path: str = None,
-            pranges: pyranges.PyRanges = None,
+            pranges: PyRanges = None,
             intervals: List[Interval] = None,
             interval_attrs: List[str] = None,
             vcf_lazy: bool = True,
@@ -173,7 +174,7 @@ class SingleVariantMatcher(BaseVariantMatcher):
         for batch in self.vcf.batch_iter(batch_size):
             yield variants_to_pyranges(batch)
 
-    def iter_pyranges(self) -> pyranges.PyRanges:
+    def iter_pyranges(self) -> PyRanges:
         """
 
         Iter matched variants with intervals as pyranges.


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/opt/conda/envs/test-kipoi-Basenji/lib/python3.5/site-packages/kipoi_utils/utils.py", line 143, in load_obj
    module = imp.load_module(module_name, fp, pathname, description)
  File "/opt/conda/envs/test-kipoi-Basenji/lib/python3.5/imp.py", line 245, in load_module
    return load_package(name, filename)
  File "/opt/conda/envs/test-kipoi-Basenji/lib/python3.5/imp.py", line 217, in load_package
    return _load(spec)
  File "<frozen importlib._bootstrap>", line 693, in _load
  File "<frozen importlib._bootstrap>", line 673, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 697, in exec_module
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "/opt/conda/envs/test-kipoi-Basenji/lib/python3.5/site-packages/kipoiseq/__init__.py", line 10, in <module>
    from . import dataloaders
  File "/opt/conda/envs/test-kipoi-Basenji/lib/python3.5/site-packages/kipoiseq/dataloaders/__init__.py", line 1, in <module>
    from .sequence import *
  File "/opt/conda/envs/test-kipoi-Basenji/lib/python3.5/site-packages/kipoiseq/dataloaders/sequence.py", line 10, in <module>
    from kipoiseq.extractors import FastaStringExtractor
  File "/opt/conda/envs/test-kipoi-Basenji/lib/python3.5/site-packages/kipoiseq/extractors/__init__.py", line 4, in <module>
    from .vcf_matching import *
  File "/opt/conda/envs/test-kipoi-Basenji/lib/python3.5/site-packages/kipoiseq/extractors/vcf_matching.py", line 19, in <module>
    def variants_to_pyranges(variants: List[Variant]) -> pyranges.PyRanges:
AttributeError: 'NoneType' object has no attribute 'PyRanges'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/conda/envs/test-kipoi-Basenji/bin/kipoi", line 11, in <module>
    sys.exit(main())
  File "/opt/conda/envs/test-kipoi-Basenji/lib/python3.5/site-packages/kipoi/__main__.py", line 105, in main
    command_fn(args.command, sys.argv[2:])
  File "/opt/conda/envs/test-kipoi-Basenji/lib/python3.5/site-packages/kipoi/cli/main.py", line 63, in cli_test
    mh = kipoi.get_model(args.model, args.source)
  File "/opt/conda/envs/test-kipoi-Basenji/lib/python3.5/site-packages/kipoi/model.py", line 117, in get_model
    default_dataloader = md.default_dataloader.get()
  File "/opt/conda/envs/test-kipoi-Basenji/lib/python3.5/site-packages/kipoi/specs.py", line 796, in get
    obj = load_obj(self.defined_as)
  File "/opt/conda/envs/test-kipoi-Basenji/lib/python3.5/site-packages/kipoi_utils/utils.py", line 148, in load_obj
    raise ImportError("object {} couldn't be imported. Error {}".format(obj_import, str(e)))
```

@Hoeze pyrange type annotation breaks the package when pyrange is not available.