### PR TITLE
Remove default arguments from xpresso

### DIFF
--- a/kipoiseq/dataloaders/sequence.py
+++ b/kipoiseq/dataloaders/sequence.py
@@ -406,10 +406,8 @@ class AnchoredGTFDl(Dataset):
                 md5: b0f5cdd4f75186f8a4d2e23378c57b5b
         num_upstream:
             doc: Number of nt by which interval is extended upstream of the anchor point
-            example: 7000
         num_downstream:
             doc: Number of nt by which interval is extended downstream of the anchor point
-            example: 3500
         gtf_filter:
             doc: >
                 Allows to filter the gtf before extracting the anchor points. Can be str, callable


### PR DESCRIPTION
Since https://github.com/kipoi/kipoi-utils/issues/28 has been fixed by https://github.com/kipoi/kipoi-utils/pull/32 I am removing example values of num_upstream and num_downstream here and adding them in Xpresso's model-template.yaml