### PR TITLE
Pin sorted-nearest to 0.0.33

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ requirements = [
     "gffutils",
     "kipoi-utils>=0.1.1",
     "kipoi-conda>=0.1.0",
+    "sorted-nearest<=0.0.33",
     "pyranges"
 ]
 


### PR DESCRIPTION
Closes: #109 
@Hoeze  Can I get a pypi release asap? I am trying to avoid pinning sorted-nearest manually in 5 kipoi repos. 

PS: I will highly recommend adding a nightly test in kipoiseq. This error would have been caught here first. Happy to provide a pr if you are interested. 