### PR TITLE
fix "gt_type != 2" to 3 (unknown)

### DIFF
--- a/kipoiseq/extractors/vcf.py
+++ b/kipoiseq/extractors/vcf.py
@@ -53,7 +53,7 @@ class MultiSampleVCF(VariantFetcher, VCF):
 
     @staticmethod
     def _has_variant_gt(gt_type: int) -> bool:
-        return gt_type != 0 and gt_type != 2
+        return gt_type != 0 and gt_type != 3
 
     def __next__(self):
         return Variant.from_cyvcf(super().__next__())


### PR DESCRIPTION
I suppose that the number in _has_variant_gt() might not be correct, because gt_type 2 is alt_homo and 3 is unknown, according to the documentation of cyvcf2.