### PR TITLE
VariantSeqExtractor fix: allow padding if sequence gets out of bounds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ variables:
         apt-get --allow-releaseinfo-change update -y  
         apt-get install build-essential -y
         conda install -y cython
-        conda install -y -c bioconda cyvcf2 pybedtools 'pysam<0.11.2.2' pyfaidx biopython
+        conda install -y -c bioconda cyvcf2 pybedtools pysam=0.10 pyfaidx biopython
   install_kipoi: &install_kipoi
     run:
       name: Install Kipoi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ variables:
         apt-get --allow-releaseinfo-change update -y  
         apt-get install build-essential -y
         conda install -y cython
-        conda install -y -c bioconda 'cyvcf2>=0.11.0' pybedtools 'pysam<0.11|>0.11' pyfaidx biopython
+        conda install -y -c bioconda 'cyvcf2>=0.11.0' pybedtools 'pysam!=0.11' pyfaidx biopython
   install_kipoi: &install_kipoi
     run:
       name: Install Kipoi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,6 @@ variables:
         apt-get --allow-releaseinfo-change update -y  
         apt-get install build-essential -y
         conda install -y cython
-#        pybedtools fails to load with 'pysam==0.11.2.2'
         conda install -y -c bioconda cyvcf2 pybedtools 'pysam<0.11.2.2' pyfaidx biopython
   install_kipoi: &install_kipoi
     run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,8 @@ variables:
         apt-get --allow-releaseinfo-change update -y  
         apt-get install build-essential -y
         conda install -y cython
-        conda install -y -c bioconda cyvcf2 pybedtools pyfaidx biopython
+#        pybedtools fails to load with 'pysam==0.11.2.2'
+        conda install -y -c bioconda cyvcf2 pybedtools 'pysam<0.11.2.2' pyfaidx biopython
   install_kipoi: &install_kipoi
     run:
       name: Install Kipoi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ variables:
         apt-get --allow-releaseinfo-change update -y  
         apt-get install build-essential -y
         conda install -y cython
-        conda install -y -c bioconda cyvcf2 pybedtools pysam=0.10 pyfaidx biopython
+        conda install -y -c bioconda 'cyvcf2>=0.11.0' pybedtools 'pysam<0.11|>0.11' pyfaidx biopython
   install_kipoi: &install_kipoi
     run:
       name: Install Kipoi

--- a/kipoiseq/extractors/vcf_seq.py
+++ b/kipoiseq/extractors/vcf_seq.py
@@ -104,7 +104,6 @@ class VariantSeqExtractor(BaseExtractor):
     def extract(self, interval, variants, anchor, fixed_len=True, use_strand=None, chrom_len=math.inf,
                 is_padding=False, **kwargs):
         """
-
         Args:
             interval: pybedtools.Interval Region of interest from
                 which to query the sequence. 0-based

--- a/kipoiseq/extractors/vcf_seq.py
+++ b/kipoiseq/extractors/vcf_seq.py
@@ -11,6 +11,7 @@ from kipoiseq.extractors import (
 
 from kipoiseq import __version__
 from deprecation import deprecated
+import math
 
 __all__ = [
     'VariantSeqExtractor',
@@ -100,7 +101,8 @@ class VariantSeqExtractor(BaseExtractor):
         """
         return self._ref_seq_extractor
 
-    def extract(self, interval, variants, anchor, fixed_len=True, use_strand=None, **kwargs):
+    def extract(self, interval, variants, anchor, fixed_len=True, use_strand=None, chrom_len=math.inf,
+                is_padding=False, **kwargs):
         """
 
         Args:
@@ -116,6 +118,8 @@ class VariantSeqExtractor(BaseExtractor):
             use_strand (bool, optional): if True, the extracted sequence
                 is reverse complemented in case interval.strand == "-".
                 Overrides `self.use_strand`
+            chrom_len: length of the chromosome. If chrom_len == math.inf, the length of the chromosome is not checked.
+            is_padding: if True, the sequence is padded with 'N's if sequence can't extend to the fixed length,
 
         Returns:
             A single sequence (`str`) with all the variants applied.
@@ -156,6 +160,9 @@ class VariantSeqExtractor(BaseExtractor):
         else:
             istart, iend = interval.start, interval.end
 
+        istart = max(istart, 0)
+        iend = min(iend, chrom_len - 1)
+
         # 4. Iterate from the anchor point outwards. At each
         # register the interval from which to take the reference sequence
         # as well as the interval for the variant
@@ -177,7 +184,7 @@ class VariantSeqExtractor(BaseExtractor):
 
         if fixed_len:
             down_str, up_str = self._cut_to_fix_len(
-                down_str, up_str, interval, anchor)
+                down_str, up_str, interval, anchor, is_padding=is_padding)
 
         seq = down_str + up_str
 
@@ -273,11 +280,27 @@ class VariantSeqExtractor(BaseExtractor):
         return seq
 
     @staticmethod
-    def _cut_to_fix_len(down_str, up_str, interval, anchor):
+    def _cut_to_fix_len(down_str, up_str, interval, anchor, is_padding=False):
         down_len = anchor - interval.start
+        down_diff = len(down_str) - down_len
+        if down_diff > 0:
+            down_str = down_str[-down_len:]
+        elif down_diff < 0:
+            if is_padding:
+                down_str = 'N' * abs(down_diff) + down_str
+            else:
+                raise ValueError(f"padding should be set to True, if the sequence can't extend to the fixed length")
+
         up_len = interval.end - anchor
-        down_str = down_str[-down_len:] if down_len else ''
-        up_str = up_str[: up_len] if up_len else ''
+        up_diff = len(up_str) - up_len
+        if up_diff > 0:
+            up_str = up_str[: up_len]
+        elif up_diff < 0:
+            if is_padding:
+                up_str = up_str + 'N' * abs(up_diff)
+            else:
+                raise ValueError(f"padding should be set to True, if the sequence can't extend to the fixed length")
+
         return down_str, up_str
 
 

--- a/setup.py
+++ b/setup.py
@@ -32,11 +32,12 @@ test_requirements = [
     "coveralls",
     "scikit-learn",
     "cython",
-    "cyvcf2",
+    "cyvcf2>=0.11.0",
     "pyranges>=0.0.71",
     # "keras",
     # "tensorflow",
     "pybedtools",
+    "pysam>0.11, <0.11"
     # "concise"
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ test_requirements = [
     # "keras",
     # "tensorflow",
     "pybedtools",
-    "pysam>0.11, <0.11"
+    "pysam!=0.11"
     # "concise"
 ]
 

--- a/tests/extractors/test_vcf_seq_extractor.py
+++ b/tests/extractors/test_vcf_seq_extractor.py
@@ -88,6 +88,12 @@ def test__split_overlapping(variant_seq_extractor):
 def test_extract(variant_seq_extractor):
     variants = [Variant.from_cyvcf(v) for v in VCF(vcf_file)]
 
+    interval = Interval('chr1', 0, 30)
+
+    seq = variant_seq_extractor.extract(interval, variants, anchor=28, fixed_len=True, is_padding=True)
+    assert len(seq) == interval.end - interval.start
+    assert seq == 'NACGCGAACGTAACGTAACGTAACGTGATA'
+
     interval = Interval('chr1', 2, 9)
 
     seq = variant_seq_extractor.extract(interval, variants, anchor=5)


### PR DESCRIPTION
In VariantSeqExtractor.extract, If there is a deletion and the interval start or end is close to the boundary, the methods returns an error. Instead allow the user to add a padding with a parameter is_padding.